### PR TITLE
Remove npm extension from extension pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the "worksome-vscode-extension-pack" extension pack will 
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.2.5]
+
+- Remove `npm` extension, as it's deprecated and supported by VSCode natively now
+
 ## [0.2.4]
 
 - Remove `php-cs-fixer` extension, as we don't use that

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Collection of recommended extensions used at Worksome.
 - [GraphQL](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql) - GraphQL extension for VSCode adds syntax highlighting, validation, and language features like go to definition, hover information and autocompletion for graphql projects. This extension also works with queries annotated with gql tag.
 - [Apollo GraphQL](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) - Rich editor support for GraphQL client and server development that seamlessly integrates with the Apollo platform
 - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) - Integrates ESLint JavaScript into VS Code.
-- [npm](https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script) - npm support for VS Code
 - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) - Code formatter - Code formatter using prettier
 - [Vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur) - Vue tooling for VS Code
 - [YAML](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) - YAML Language Support by Red Hat, with built-in Kubernetes syntax support

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
         "GraphQL.vscode-graphql",
         "apollographql.vscode-apollo",
         "dbaeumer.vscode-eslint",
-        "eg2.vscode-npm-script",
         "esbenp.prettier-vscode",
         "octref.vetur",
         "redhat.vscode-yaml",


### PR DESCRIPTION
Delete the npm extension from the recommended extensions list as it's currently deprecated

<img width="1500" alt="image" src="https://github.com/user-attachments/assets/83470762-1d99-4119-8521-c0399cf1453d" />
